### PR TITLE
Cargo: don't specify version in Cargo.toml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,13 +28,13 @@ jobs:
         run: |
           echo "version is: $VERSION"
 
-      - name: Check that tag version and Cargo.toml version are the same
-        shell: bash
-        run: |
-          if ! grep -q "version = \"$VERSION\"" Cargo.toml; then
-            echo "version does not match Cargo.toml" >&2
-            exit 1
-          fi
+      # - name: Check that tag version and Cargo.toml version are the same
+      #   shell: bash
+      #   run: |
+      #     if ! grep -q "version = \"$VERSION\"" Cargo.toml; then
+      #       echo "version does not match Cargo.toml" >&2
+      #       exit 1
+      #     fi
 
       - name: Create GitHub release
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "dsa_hybrid_editor"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa_hybrid_editor"
-version = "1.0.0"
+version = "0.0.0"
 authors = ["Pantos <pantos+github@akk.org>"]
 edition = "2024"
 publish = false


### PR DESCRIPTION
This makes creating releases much easier. Also there is no publishing to `crates.io`, so the version in `Cargo.toml` is completely optional anyway.